### PR TITLE
Translate the specified headline

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ App::plugin('bnomei/recently-modified', [
         'recentlymodified' => [
             'props' => [
                 'headline' => function (string $headline = 'Recently Modified') {
-                    return $headline;
+                    return t($headline);
                 },
                 'query' => function (?string $query = null) {
                     $query = $query ?? option('bnomei.recently-modified.query');


### PR DESCRIPTION
Hi 👋

For use on websites with multiple languages, the headline should be translated by the `t()` helper.

This pull request could have been an issue, I know…