### PR TITLE
fix: Use kirby()->contentExtension() instead of the option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Kirby Section to display recently modified content pages",
   "license": "MIT",
   "type": "kirby-plugin",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "authors": [
     {
       "name": "Bruno Meilick",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd507de13a40182f398255beaeb50be7",
+    "content-hash": "6980244a4e82100895b6c3b3b53d7a73",
     "packages": [
         {
             "name": "getkirby/composer-installer",

--- a/index.php
+++ b/index.php
@@ -94,15 +94,26 @@ App::plugin('bnomei/recently-modified', [
             return pages($keys ?? []);
         },
         'modifiedTimestamp' => function () {
-            $t = filemtime(
-                site()->root()
-                    . (
-                        kirby()->multilang()
-                            ? '/site.' . kirby()->defaultLanguage()->code() . '.' . kirby()->contentExtension()
-                            : '/site.' . kirby()->contentExtension()
-                    ),
-            );
-            return $t ?: time();
+            $root = site()->root();
+            $extension = kirby()->contentExtension();
+            $files = [];
+
+            if (kirby()->multilang()) {
+                foreach (kirby()->languages() as $language) {
+                    $files[] = $root . '/site.' . $language->code() . '.' . $extension;
+                }
+            } else {
+                $files[] = $root . '/site.' . $extension;
+            }
+
+            $timestamps = [];
+            foreach ($files as $file) {
+                if (is_file($file) && ($modified = filemtime($file)) !== false) {
+                    $timestamps[] = $modified;
+                }
+            }
+
+            return empty($timestamps) ? time() : max($timestamps);
         },
         'trackModifiedByUser' => function (bool $add = true): bool {
             if (!kirby()->user() || option('bnomei.recently-modified.hooks') !== true) {

--- a/index.php
+++ b/index.php
@@ -98,8 +98,8 @@ App::plugin('bnomei/recently-modified', [
                 site()->root()
                     . (
                         kirby()->multilang()
-                            ? '/site.' . kirby()->defaultLanguage()->code() . '.' . option('content.extension')
-                            : '/site.' . option('content.extension')
+                            ? '/site.' . kirby()->defaultLanguage()->code() . '.' . kirby()->contentExtension()
+                            : '/site.' . kirby()->contentExtension()
                     ),
             );
             return $t ?: time();

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -7,8 +7,4 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
-    'Kirby\\ComposerInstaller\\CmsInstaller' => $vendorDir . '/getkirby/composer-installer/src/ComposerInstaller/CmsInstaller.php',
-    'Kirby\\ComposerInstaller\\Installer' => $vendorDir . '/getkirby/composer-installer/src/ComposerInstaller/Installer.php',
-    'Kirby\\ComposerInstaller\\Plugin' => $vendorDir . '/getkirby/composer-installer/src/ComposerInstaller/Plugin.php',
-    'Kirby\\ComposerInstaller\\PluginInstaller' => $vendorDir . '/getkirby/composer-installer/src/ComposerInstaller/PluginInstaller.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -22,10 +22,6 @@ class ComposerStaticInit505107e9cd1d25194956b98f2c30aa00
 
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
-        'Kirby\\ComposerInstaller\\CmsInstaller' => __DIR__ . '/..' . '/getkirby/composer-installer/src/ComposerInstaller/CmsInstaller.php',
-        'Kirby\\ComposerInstaller\\Installer' => __DIR__ . '/..' . '/getkirby/composer-installer/src/ComposerInstaller/Installer.php',
-        'Kirby\\ComposerInstaller\\Plugin' => __DIR__ . '/..' . '/getkirby/composer-installer/src/ComposerInstaller/Plugin.php',
-        'Kirby\\ComposerInstaller\\PluginInstaller' => __DIR__ . '/..' . '/getkirby/composer-installer/src/ComposerInstaller/PluginInstaller.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,18 +1,18 @@
 <?php return array(
     'root' => array(
         'name' => 'bnomei/kirby3-recently-modified',
-        'pretty_version' => '5.0.3',
-        'version' => '5.0.3.0',
+        'pretty_version' => '5.0.4',
+        'version' => '5.0.4.0',
         'reference' => null,
         'type' => 'kirby-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'dev' => false,
+        'dev' => true,
     ),
     'versions' => array(
         'bnomei/kirby3-recently-modified' => array(
-            'pretty_version' => '5.0.3',
-            'version' => '5.0.3.0',
+            'pretty_version' => '5.0.4',
+            'version' => '5.0.4.0',
             'reference' => null,
             'type' => 'kirby-plugin',
             'install_path' => __DIR__ . '/../../',


### PR DESCRIPTION
Hi Bruno,
I’ve been getting an error when saving some pages, which is because a content file couldn’t be found.

The problem seems to be related to the fact that I’m running Kirby in multi-language mode, have configured a custom content root, and haven’t set the `content.extension` option manually.

In my example, the file `site.de.txt` exists in the correct location, but the [path used in the plugin is incomplete.](https://github.com/bnomei/kirby3-recently-modified/blob/main/index.php#L97)

```php
filemtime(): stat failed for […]/site.de.
```

The problem could be resolved by adding a `file_exists` guard to `filemtime()` or by using `kirby()->contentExtension()` instead of the option.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate site "last modified" timestamps in multilingual sites by checking all language-specific candidates and using the latest available timestamp (falls back to current time if unavailable).

* **Chore**
  * Package version bumped to 5.0.4 and related metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->